### PR TITLE
Success failure functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,5 @@ RUN apk add --no-cache python3 && \
 WORKDIR /
 
 COPY cleaner.py /
-COPY scm-source.json /
 
 ENTRYPOINT ["/cleaner.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test docker push
 
-IMAGE            ?= hjacobs/kube-job-cleaner
+IMAGE            ?= gcr.io/freenome-services-dev/kube-job-cleaner
 VERSION          ?= $(shell git describe --tags --always --dirty)
 TAG              ?= $(VERSION)
 GITHEAD          = $(shell git rev-parse --short HEAD)
@@ -9,16 +9,10 @@ GITSTATUS        = $(shell git status --porcelain || echo "no changes")
 
 default: docker
 
-test:
-	tox
-
-docker: scm-source.json
+docker:
 	docker build -t "$(IMAGE):$(TAG)" .
 	@echo 'Docker image $(IMAGE):$(TAG) can now be used.'
 
 push: docker
 	docker push "$(IMAGE):$(TAG)"
-
-scm-source.json: .git
-	@echo '{"url": "git:$(GITURL)", "revision": "$(GITHEAD)", "author": "$(USER)", "status": "$(GITSTATUS)"}' > scm-source.json
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test docker push
 
-IMAGE            ?= gcr.io/freenome-services-dev/kube-job-cleaner
+IMAGE            ?= gcr.io/freenome-build/kube-job-cleaner
 VERSION          ?= $(shell git describe --tags --always --dirty)
 TAG              ?= $(VERSION)
 GITHEAD          = $(shell git rev-parse --short HEAD)

--- a/cleaner.py
+++ b/cleaner.py
@@ -31,8 +31,8 @@ def job_expired(success_max_age, failure_max_age, timeout_seconds, job):
             return '{:.0f}s old and succeeded'.format(seconds_since_completion)
         # job pod was not created and we fell back to creationTimestamp, or status.get('failure')
         # was found. Either way, we treat these as failure cases.
-        elif seconds_since_completion > failure_max_age:
-            return '{:.0f}s old and failed'
+        elif not status.get('succeeded') and seconds_since_completion > failure_max_age:
+            return '{:.0f}s old and failed'.format(seconds_since_completion)
 
     start_time = status.get('startTime')
     if start_time:


### PR DESCRIPTION
## Summary
Adding functionality to specify separately a max time for successful jobs and failed jobs.

Successful jobs default to one day, and failed jobs defaults to -1. This means that successful completed jobs will be cleaned up within a day, but failed jobs will not be touched by the script by default.